### PR TITLE
ウィンドウ位置調整によるリサイズ時のエラー回避 (v1.21)

### DIFF
--- a/index.css
+++ b/index.css
@@ -18,11 +18,20 @@ button {
     text-align: center;
 }
 
-.nowrap,
-#testText {
+.nowrap {
     margin-bottom: 4px;
     font-size: small;
     white-space: nowrap;
+}
+
+#testText {
+    white-space: pre-wrap;
+}
+
+.displayInfo {
+    font-size: small;
+    white-space: nowrap;
+    text-align: right;
 }
 
 #currentPosition,

--- a/index.css
+++ b/index.css
@@ -1,10 +1,10 @@
 body {
-    margin: 10px;
+    margin: 8px;
 }
 
 button {
-    padding: 5px 10px;
-    margin: 5px;
+    padding: 4px 8px;
+    margin: 4px;
     white-space: nowrap;
 }
 
@@ -14,23 +14,27 @@ button {
 
 #presets,
 #btn {
-    margin: 5px 0;
+    margin: 4px 0;
     text-align: center;
+}
+
+.nowrap,
+#testText {
+    margin-bottom: 4px;
+    font-size: small;
+    white-space: nowrap;
 }
 
 #currentPosition,
 #currentSize,
-#version,
-#testText {
-    display: block;
-    margin-bottom: 5px;
+#version {
     font-size: small;
     white-space: nowrap;
     text-align: right;
 }
 
 input[type="number"] {
-    width: 50px;
+    width: 64px;
 }
 
 table {
@@ -51,7 +55,7 @@ td {
 }
 
 .highlight {
-    background-color: black;
+    background-color: rgb(127, 255, 192);
     color: white;
     transition: background-color 0.5s, color 0.5s;
 }

--- a/index.css
+++ b/index.css
@@ -9,6 +9,10 @@ button {
 }
 
 #back {
+    float: center;
+}
+
+#reset {
     float: right;
 }
 

--- a/index.css
+++ b/index.css
@@ -9,11 +9,27 @@ button {
 }
 
 #back {
-    float: center;
+    float: right;
 }
 
 #reset {
-    float: right;
+    float: left;
+    /* 赤で強調 */
+    background-color: #FF4C4C;
+    /* 文字色は白でコントラスト確保 */
+    color: white;
+    font-weight: bold;
+    border-radius: 2px;
+    padding: 2px 4px;
+}
+
+.settingsPanel {
+    display: none;
+}
+
+#reset:hover {
+    /* ホバー時にさらに濃い赤 */
+    background-color: #CC0000;
 }
 
 #presets,

--- a/index.html
+++ b/index.html
@@ -59,11 +59,10 @@
         <div id="presets"></div>
         <!-- ▲プリセットボタン表示 -->
         <!-- ▼設定画面 -->
-        <div id="settingsPanel" style="display:none;">
+        <div class="settingsPanel">
             <h2>
                 <span>⚙ Settings</span>
-                <button id="back"> ◀ Back</button>
-                <button id="reset"> Reset</button>
+                <button id="back"> ↩️ Back</button>
             </h2>
             <table>
                 <!--thead>
@@ -102,6 +101,7 @@
             <span id="currentSize"> - × - </span>
         </div>
         <hr />
+        <button id="reset" class="settingsPanel"> 🔄 Reset</button>
         <div id="version"></div>
 
         <script src="popup.js"></script>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
             <h2>
                 <span>⚙ Settings</span>
                 <button id="back"> ◀ Back</button>
+                <button id="reset"> Reset</button>
             </h2>
             <table>
                 <!--thead>

--- a/index.html
+++ b/index.html
@@ -64,14 +64,14 @@
                 <button id="back"> ◀ Back</button>
             </h2>
             <table>
-                <tbody>
+                <!--thead>
                     <tr>
                         <th>
                             <span class="nowrap">Width × Height</span>
                         </th>
                         <th></th>
                     </tr>
-                </tbody>
+                </thead-->
                 <tbody id="presetList"></tbody>
                 </tbody>
                 <tbody>
@@ -79,7 +79,9 @@
                         <form id="presetForm">
                             <td>
                                 <span class="nowrap">
-                                    <input id="newWidth" type="number"> × <input id="newHeight" type="number">
+                                    <input id="newWidth" type="number" placeholder="Width">
+                                    ×
+                                    <input id="newHeight" type="number" placeholder="Height">
                                 </span>
                             </td>
                             <td>

--- a/index.html
+++ b/index.html
@@ -52,14 +52,12 @@
     </head>
 
     <body>
-        <div id="testText"></div>
-        <span id="currentPosition"> Position: - × - </span>
-        <span id="currentSize"> Size: - × - </span>
-        <div id="presets"></div>
-        <hr />
         <div id="btn">
             <button id="settings"> ⚙ Settings</button>
         </div>
+        <div id="presets"></div>
+        <!-- ▲プリセットボタン表示 -->
+        <!-- ▼設定画面 -->
         <div id="settingsPanel" style="display:none;">
             <h2>
                 <span>⚙ Settings</span>
@@ -68,23 +66,35 @@
             <table>
                 <tbody>
                     <tr>
-                        <th>Width</th>
-                        <th>Height</th>
+                        <th>
+                            <span class="nowrap">Width × Height</span>
+                        </th>
                         <th></th>
                     </tr>
-                    <tr>
-                        <form id="presetForm">
-                            <td><input id="newWidth" type="number"></td>
-                            <td><input id="newHeight" type="number"></td>
-                            <td><button id="addPreset"> ⊕ Add</button></td>
-                        </form>
-                    </tr>
+                </tbody>
                 <tbody id="presetList"></tbody>
                 </tbody>
+                <tbody>
+                    <tr>
+                        <form id="presetForm">
+                            <td>
+                                <span class="nowrap">
+                                    <input id="newWidth" type="number"> × <input id="newHeight" type="number">
+                                </span>
+                            </td>
+                            <td>
+                                <button id="addPreset"> ⊕ Add</button>
+                            </td>
+                        </form>
+                    </tr>
+                </tbody>
             </table>
-            <div id="version">
-            </div>
         </div>
+        <div id="testText"></div>
+        <span id="currentPosition"> Position: - × - </span>
+        <span id="currentSize"> Size: - × - </span>
+        <hr />
+        <div id="version"></div>
 
         <script src="popup.js"></script>
     </body>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
         <div id="btn">
             <button id="settings"> ⚙ Settings</button>
         </div>
+
         <div id="presets"></div>
         <!-- ▲プリセットボタン表示 -->
         <!-- ▼設定画面 -->
@@ -92,9 +93,13 @@
                 </tbody>
             </table>
         </div>
-        <div id="testText"></div>
-        <span id="currentPosition"> Position: - × - </span>
-        <span id="currentSize"> Size: - × - </span>
+
+        <div id="testText" style="white-space: pre-wrap;"></div>
+        <div id="displays"></div>
+        <div class="displayInfo">
+            <span id="currentPosition"> Window: ( - , - ) </span>
+            <span id="currentSize"> - × - </span>
+        </div>
         <hr />
         <div id="version"></div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
         "windows",
         "storage",
         "activeTab",
-        "scripting"
+        "scripting",
+        "system.display"
     ],
     "action": {
         "default_popup": "index.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Resize Active Window アクティブなブラウザウィンドウのサイズを変更",
-    "version": "1.2",
+    "version": "1.21",
     "permissions": [
         "windows",
         "storage",
@@ -10,7 +10,7 @@
     ],
     "action": {
         "default_popup": "index.html",
-        "default_title": "Resize Window"
+        "default_title": "Resize Active Window"
     },
     "icons": {
         "16": "icon-16x16.png",

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,19 @@
 const windowThickness = 8; // ウィンドウ枠の厚さを考慮
+const presets = {
+    presets: [{
+        width: 816,
+        height: 568
+    }, {
+        width: 1040,
+        height: 756
+    }, {
+        width: 1296,
+        height: 768
+    }, {
+        width: 1936,
+        height: 1048
+    }]
+};
 
 /** Render the preset buttons
  * プリセットボタンの表示と動作設定
@@ -10,21 +25,7 @@ const windowThickness = 8; // ウィンドウ枠の厚さを考慮
 function renderPresets() {
     chrome.storage.local.get({ presets: [] }, (data) => {
         if (data.presets.length === 0) {
-            chrome.storage.local.set({
-                presets: [{
-                    width: 816,
-                    height: 560
-                }, {
-                    width: 1040,
-                    height: 748
-                }, {
-                    width: 1296,
-                    height: 760
-                }, {
-                    width: 1936,
-                    height: 1040
-                }]
-            }, renderPresets);
+            chrome.storage.local.set(presets, renderPresets);
         } else {
             const container = document.getElementById("presets");
             container.innerHTML = ""; // 既存の内容をクリア
@@ -43,10 +44,10 @@ function renderPresets() {
                             const targetDisplay = displays.find(d => {
                                 const bounds = d.bounds;
                                 //testText(JSON.stringify(bounds));
-                                return rightX >= bounds.left &&
-                                    rightX <= bounds.left + bounds.width &&
-                                    topY >= bounds.top &&
-                                    topY <= bounds.top + bounds.height;
+                                return rightX >= bounds.left + windowThickness + 1 &&
+                                    rightX <= bounds.left + bounds.width + windowThickness + 1 &&
+                                    topY >= bounds.top - windowThickness - 1 &&
+                                    topY <= bounds.top + bounds.height - windowThickness - 1;
                             }) || displays[0]; // 見つからなければプライマリ
                             // 画面の利用可能領域(除くタスクバー)を取得
                             const screenWidth = targetDisplay.workArea.width;
@@ -59,11 +60,11 @@ function renderPresets() {
                             let targetWidth = parameter.width;
                             let targetHeight = parameter.height;
                             if (targetWidth > screenWidth + windowThickness * 2) targetWidth = screenWidth + windowThickness * 2;
-                            if (targetHeight > screenHeight + windowThickness) targetHeight = screenHeight + windowThickness;
+                            if (targetHeight > screenHeight + windowThickness * 2) targetHeight = screenHeight + windowThickness * 2;
 
                             // 位置補正（拡張機能ボタンがある右上基準）
                             let newLeft = window.left + window.width - targetWidth;
-                            let newTop = window.top;
+                            let newTop = window.top - windowThickness;
 
                             // 画面左にはみ出さないように調整
                             if (newLeft < screenLeft - windowThickness) {
@@ -71,14 +72,14 @@ function renderPresets() {
                             }
                             // 画面上にはみ出さないように調整
                             if (newTop < screenTop - windowThickness) {
-                                newTop = screenTop;
+                                newTop = screenTop - windowThickness;
                             }
                             // 画面右にはみ出さないように調整
                             if (newLeft + targetWidth > screenLeft + screenWidth + windowThickness) {
                                 newLeft = screenLeft + screenWidth - targetWidth + windowThickness;
                             }
                             // 画面下にはみ出さないように調整
-                            if (newTop + targetHeight > screenTop + screenHeight + windowThickness * 2) {
+                            if (newTop + targetHeight > screenTop + screenHeight + windowThickness) {
                                 newTop = screenTop + screenHeight - targetHeight + windowThickness;
                             }
 
@@ -173,7 +174,9 @@ document.getElementById("presetForm").addEventListener("submit", (e) => {
 document.getElementById("settings").onclick = () => {
     document.getElementById("presets").style.display = "none";
     document.getElementById("btn").style.display = "none";
-    document.getElementById("settingsPanel").style.display = "block";
+    Array.from(
+        document.getElementsByClassName("settingsPanel")
+    ).forEach(el => el.style.display = "block");
     renderSettings();
 };
 
@@ -184,8 +187,29 @@ document.getElementById("settings").onclick = () => {
 document.getElementById("back").onclick = () => {
     document.getElementById("presets").style.display = "block";
     document.getElementById("btn").style.display = "block";
-    document.getElementById("settingsPanel").style.display = "none";
+    Array.from(
+        document.getElementsByClassName("settingsPanel")
+    ).forEach(el => el.style.display = "none");
     renderPresets();
+};
+
+/** Promisified version of chrome.storage.local.set
+ * chrome.storage.local.set の Promise 版
+ * @param {Object} data - data to store
+ * @returns {Promise<void>} Promise that resolves when set is complete
+ */
+function setStorageAsync(data) {
+    return new Promise(resolve => {
+        chrome.storage.local.set(data, resolve);
+    });
+}
+
+// Reset ボタンのクリック処理
+document.getElementById("reset").onclick = async () => {
+    // ストレージを初期化
+    await setStorageAsync(presets);
+    // 設定画面を再描画
+    renderSettings();
 };
 
 /** Handle add preset button click

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,5 @@
 /** Render the preset buttons
+ * プリセットボタンの表示
  * Each button resizes the current window to the preset dimensions
  * Also handles settings panel for adding/removing presets
  * Uses chrome.storage.local to persist presets
@@ -10,7 +11,9 @@ function renderPresets() {
             chrome.storage.local.set({ presets: [{ width: 800, height: 600 }] }, renderPresets);
         } else {
             const container = document.getElementById("presets");
-            container.innerHTML = "";
+            container.innerHTML = ""; // 既存の内容をクリア
+            const hr = document.createElement("hr");
+            container.appendChild(hr);
             data.presets.forEach((parameter) => {
                 const presetBtn = document.createElement("button");
                 presetBtn.textContent = `${parameter.width}x${parameter.height}`;
@@ -28,12 +31,17 @@ function renderPresets() {
                     });
                 };
                 container.appendChild(presetBtn);
+                const br = document.createElement("br");
+                container.appendChild(br);
             });
+            const hr2 = document.createElement("hr");
+            container.appendChild(hr2);
         }
     });
 }
 
 /** Render the settings panel for managing presets
+ * 設定画面のプリセット一覧を表示
  * @returns {void}
  */
 function renderSettings(highlightIndex = null) {
@@ -41,10 +49,8 @@ function renderSettings(highlightIndex = null) {
         const listRow = document.getElementById("presetList");
         listRow.innerHTML = "";
         data.presets.forEach((p, i) => {
-            const tdWidth = document.createElement("td");
-            tdWidth.textContent = p.width;
-            const tdHeight = document.createElement("td");
-            tdHeight.textContent = p.height;
+            const td = document.createElement("td");
+            td.textContent = p.width + " × " + p.height;
             const tdDelete = document.createElement("td");
             const deleteBtn = document.createElement("button");
             deleteBtn.textContent = " 🗑️ Delete";
@@ -55,8 +61,7 @@ function renderSettings(highlightIndex = null) {
             tdDelete.appendChild(deleteBtn);
 
             const tr = document.createElement("tr");
-            tr.appendChild(tdWidth);
-            tr.appendChild(tdHeight);
+            tr.appendChild(td);
             tr.appendChild(tdDelete);
             listRow.appendChild(tr);
 
@@ -72,6 +77,7 @@ function renderSettings(highlightIndex = null) {
 }
 
 /** Add a new preset from input fields
+ * 新しいプリセットを追加
  * @returns {void}
  */
 function addPreset() {
@@ -97,6 +103,7 @@ document.getElementById("presetForm").addEventListener("submit", (e) => {
 });
 
 /** Handle settings button click
+ * 設定ボタンのクリックで呼び出し
  * @returns {void}
  */
 document.getElementById("settings").onclick = () => {
@@ -107,6 +114,7 @@ document.getElementById("settings").onclick = () => {
 };
 
 /** Handle back button click
+ * 設定画面から戻るボタンの処理
  * @returns {void}
  */
 document.getElementById("back").onclick = () => {
@@ -126,6 +134,7 @@ document.getElementById("addPreset").onclick = (e) => {
 };
 
 /** Update and display current window size and position
+ * ウィンドウのサイズと位置を取得して表示
  * @returns {void}
  */
 function updateWindowInfo() {
@@ -171,7 +180,7 @@ function updateWindowInfo() {
  * @returns {void}
  */
 function testText(textContent) {
-    //document.getElementById("testText").textContent = textContent;
+    document.getElementById("testText").textContent = textContent;
 }
 
 /** Main function to initialize the popup
@@ -183,7 +192,7 @@ function main() {
     renderPresets();
     // バージョン情報の表示
     const manifest = chrome.runtime.getManifest();
-    document.getElementById("version").textContent = `${manifest.name} Version: ${manifest.version}`;
+    document.getElementById("version").innerHTML = `${manifest.action.default_title}<br /> Version: ${manifest.version}`;
 }
 
 main();

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,7 @@
+const windowFrameThickness = -8; // ウィンドウ枠の厚さを考慮
+
 /** Render the preset buttons
- * プリセットボタンの表示
+ * プリセットボタンの表示と動作設定
  * Each button resizes the current window to the preset dimensions
  * Also handles settings panel for adding/removing presets
  * Uses chrome.storage.local to persist presets
@@ -12,36 +14,75 @@ function renderPresets() {
         } else {
             const container = document.getElementById("presets");
             container.innerHTML = ""; // 既存の内容をクリア
-            const hr = document.createElement("hr");
-            container.appendChild(hr);
+            container.appendChild(document.createElement("hr"));
             data.presets.forEach((parameter) => {
                 const presetBtn = document.createElement("button");
                 presetBtn.textContent = `${parameter.width}x${parameter.height}`;
                 presetBtn.className = "preset";
                 presetBtn.onclick = () => {
                     chrome.windows.getCurrent({}, (window) => {
-                        const newLeft = window.left + window.width - parameter.width;
+                        // 画面の利用可能領域
+                        let screenWidth = window.width;
+                        let screenHeight = window.height;
+
+                        // 拡張機能が表示される右上を基準に表示画面の利用可能領域を取得
+                        const rightX = window.left + screenWidth;
+                        const topY = window.top;
+                        chrome.system.display.getInfo((displays) => {
+                            // 右上座標が属するディスプレイを探す
+                            const display = displays.find(d => {
+                                const b = d.bounds;
+                                testText(JSON.stringify(b));
+                                return rightX >= b.left &&
+                                    rightX <= b.left + b.width &&
+                                    topY >= b.top &&
+                                    topY <= b.top + b.height;
+                            }) || displays[0]; // 見つからなければプライマリ
+
+                            // 画面の利用可能領域を取得
+                            screenWidth = display.workArea.width;
+                            screenHeight = display.workArea.height;
+                        });
+
+                        // 上限補正
+                        let targetWidth = parameter.width;
+                        let targetHeight = parameter.height;
+                        if (targetWidth > screenWidth) targetWidth = screenWidth;
+                        if (targetHeight > screenHeight) targetHeight = screenHeight;
+
+                        // 位置補正（右上固定）
+                        let newLeft = window.left + window.width - targetWidth;
+                        let newTop = window.top;
+
+                        // 画面外にはみ出さないように調整
+                        if (newLeft < 0 + windowFrameThickness) newLeft = 0 + windowFrameThickness;
+                        if (newTop < 0 + windowFrameThickness) newTop = 0 + windowFrameThickness;
+                        if (newLeft + targetWidth > screenWidth - windowFrameThickness) newLeft = screenWidth - targetWidth - windowFrameThickness;
+                        if (newTop + targetHeight > screenHeight - windowFrameThickness) newTop = screenHeight - targetHeight - windowFrameThickness;
+
+                        // ウィンドウサイズと位置を変更
                         chrome.windows.update(
                             window.id,
                             {
-                                width: parameter.width,
-                                height: parameter.height,
-                                left: newLeft
-                            });
+                                width: targetWidth,
+                                height: targetHeight,
+                                left: newLeft,
+                                top: newTop
+                            }
+                        );
                     });
                 };
                 container.appendChild(presetBtn);
                 const br = document.createElement("br");
                 container.appendChild(br);
             });
-            const hr2 = document.createElement("hr");
-            container.appendChild(hr2);
+            container.appendChild(document.createElement("hr"));
         }
     });
 }
 
 /** Render the settings panel for managing presets
- * 設定画面のプリセット一覧を表示
+ * 設定画面のプリセットボタン一覧を表示
  * @returns {void}
  */
 function renderSettings(highlightIndex = null) {
@@ -77,7 +118,7 @@ function renderSettings(highlightIndex = null) {
 }
 
 /** Add a new preset from input fields
- * 新しいプリセットを追加
+ * 新しいプリセットボタンを追加
  * @returns {void}
  */
 function addPreset() {
@@ -94,7 +135,7 @@ function addPreset() {
     });
 }
 
-/** フォーム全体で Enter キーを拾う
+/** フォーム全体で Enter キーを拾い、プリセットボタン保存を呼び出す
  * @returns {void}
  */
 document.getElementById("presetForm").addEventListener("submit", (e) => {
@@ -103,7 +144,7 @@ document.getElementById("presetForm").addEventListener("submit", (e) => {
 });
 
 /** Handle settings button click
- * 設定ボタンのクリックで呼び出し
+ * 設定ボタンのクリックで設定画面呼び出し
  * @returns {void}
  */
 document.getElementById("settings").onclick = () => {
@@ -114,7 +155,7 @@ document.getElementById("settings").onclick = () => {
 };
 
 /** Handle back button click
- * 設定画面から戻るボタンの処理
+ * 設定画面で戻るボタンからメニュー画面へ切り替え
  * @returns {void}
  */
 document.getElementById("back").onclick = () => {
@@ -125,7 +166,7 @@ document.getElementById("back").onclick = () => {
 };
 
 /** Handle add preset button click
- * Add ボタンのクリックでも呼び出し
+ * Add ボタンのクリックでもプリセットボタン保存を呼び出す
  * @returns {void}
  */
 document.getElementById("addPreset").onclick = (e) => {
@@ -141,10 +182,10 @@ function updateWindowInfo() {
     let contentText = `- × -`;
     chrome.windows.getCurrent({}, (win) => {
         contentText =
-            `Size: ${win.width} × ${win.height}`;
+            ` ${win.width} × ${win.height}`;
         document.getElementById("currentSize").textContent = contentText;
         document.getElementById("currentPosition").textContent =
-            `Position: ${win.left} × ${win.top}`;
+            `Window: ( ${win.left} , ${win.top} ) `;
     });
 
     // タブの表示領域サイズ
@@ -180,6 +221,7 @@ function updateWindowInfo() {
 }
 
 /** Test function to display text in the popup
+ * テスト用関数：ポップアップ内にテキスト表示
  * @param {string} textContent - text to display
  * @returns {void}
  */
@@ -187,13 +229,39 @@ function testText(textContent) {
     document.getElementById("testText").textContent = textContent;
 }
 
+/** Format display information as a string
+ * ディスプレイ情報を文字列化
+ * @param {Object} display - display object from chrome.system.display.getInfo
+ * @returns {string} formatted display information
+ */
+function displayInfo(display) {
+    const name = display.name || `Display${display.id}`;
+    const bounds = display.bounds;
+    const position = `(${bounds.left}, ${bounds.top})`;
+    const size = `${bounds.width} x ${bounds.height}`;
+    return `<div class="displayInfo">${name} : ${position} ${size}</div>`;
+}
+
 /** Main function to initialize the popup
+ * ポップアップの初期化処理
  * @returns {void}
  */
 function main() {
     updateWindowInfo();
     chrome.windows.onBoundsChanged.addListener(updateWindowInfo);
     renderPresets();
+
+    // ディスプレイ情報の表示
+    chrome.system.display.getInfo((displays) => {
+        const displayInfoDiv = document.getElementById("displays");
+        displayInfoDiv.innerHTML = "";
+        let displayInfoText = "";
+        displays.forEach(display => {
+            //testText(JSON.stringify(display));
+            displayInfoText += displayInfo(display);
+        });
+        displayInfoDiv.innerHTML = displayInfoText;
+    });
 
     // バージョン情報の表示
     const manifest = chrome.runtime.getManifest();

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,4 @@
-const windowFrameThickness = -8; // ウィンドウ枠の厚さを考慮
+const windowThickness = 8; // ウィンドウ枠の厚さを考慮
 
 /** Render the preset buttons
  * プリセットボタンの表示と動作設定
@@ -10,7 +10,21 @@ const windowFrameThickness = -8; // ウィンドウ枠の厚さを考慮
 function renderPresets() {
     chrome.storage.local.get({ presets: [] }, (data) => {
         if (data.presets.length === 0) {
-            chrome.storage.local.set({ presets: [{ width: 800, height: 600 }] }, renderPresets);
+            chrome.storage.local.set({
+                presets: [{
+                    width: 816,
+                    height: 560
+                }, {
+                    width: 1040,
+                    height: 748
+                }, {
+                    width: 1296,
+                    height: 760
+                }, {
+                    width: 1936,
+                    height: 1040
+                }]
+            }, renderPresets);
         } else {
             const container = document.getElementById("presets");
             container.innerHTML = ""; // 既存の内容をクリア
@@ -21,55 +35,64 @@ function renderPresets() {
                 presetBtn.className = "preset";
                 presetBtn.onclick = () => {
                     chrome.windows.getCurrent({}, (window) => {
-                        // 画面の利用可能領域
-                        let screenWidth = window.width;
-                        let screenHeight = window.height;
-
                         // 拡張機能が表示される右上を基準に表示画面の利用可能領域を取得
-                        const rightX = window.left + screenWidth;
+                        const rightX = window.left + window.width;
                         const topY = window.top;
                         chrome.system.display.getInfo((displays) => {
                             // 右上座標が属するディスプレイを探す
-                            const display = displays.find(d => {
-                                const b = d.bounds;
-                                testText(JSON.stringify(b));
-                                return rightX >= b.left &&
-                                    rightX <= b.left + b.width &&
-                                    topY >= b.top &&
-                                    topY <= b.top + b.height;
+                            const targetDisplay = displays.find(d => {
+                                const bounds = d.bounds;
+                                //testText(JSON.stringify(bounds));
+                                return rightX >= bounds.left &&
+                                    rightX <= bounds.left + bounds.width &&
+                                    topY >= bounds.top &&
+                                    topY <= bounds.top + bounds.height;
                             }) || displays[0]; // 見つからなければプライマリ
+                            // 画面の利用可能領域(除くタスクバー)を取得
+                            const screenWidth = targetDisplay.workArea.width;
+                            const screenHeight = targetDisplay.workArea.height;
+                            const screenLeft = targetDisplay.workArea.left;
+                            const screenTop = targetDisplay.workArea.top;
+                            //testText(JSON.stringify(targetDisplay.workArea));
 
-                            // 画面の利用可能領域を取得
-                            screenWidth = display.workArea.width;
-                            screenHeight = display.workArea.height;
-                        });
+                            // サイズ上限補正
+                            let targetWidth = parameter.width;
+                            let targetHeight = parameter.height;
+                            if (targetWidth > screenWidth + windowThickness * 2) targetWidth = screenWidth + windowThickness * 2;
+                            if (targetHeight > screenHeight + windowThickness) targetHeight = screenHeight + windowThickness;
 
-                        // 上限補正
-                        let targetWidth = parameter.width;
-                        let targetHeight = parameter.height;
-                        if (targetWidth > screenWidth) targetWidth = screenWidth;
-                        if (targetHeight > screenHeight) targetHeight = screenHeight;
+                            // 位置補正（拡張機能ボタンがある右上基準）
+                            let newLeft = window.left + window.width - targetWidth;
+                            let newTop = window.top;
 
-                        // 位置補正（右上固定）
-                        let newLeft = window.left + window.width - targetWidth;
-                        let newTop = window.top;
-
-                        // 画面外にはみ出さないように調整
-                        if (newLeft < 0 + windowFrameThickness) newLeft = 0 + windowFrameThickness;
-                        if (newTop < 0 + windowFrameThickness) newTop = 0 + windowFrameThickness;
-                        if (newLeft + targetWidth > screenWidth - windowFrameThickness) newLeft = screenWidth - targetWidth - windowFrameThickness;
-                        if (newTop + targetHeight > screenHeight - windowFrameThickness) newTop = screenHeight - targetHeight - windowFrameThickness;
-
-                        // ウィンドウサイズと位置を変更
-                        chrome.windows.update(
-                            window.id,
-                            {
-                                width: targetWidth,
-                                height: targetHeight,
-                                left: newLeft,
-                                top: newTop
+                            // 画面左にはみ出さないように調整
+                            if (newLeft < screenLeft - windowThickness) {
+                                newLeft = screenLeft - windowThickness;
                             }
-                        );
+                            // 画面上にはみ出さないように調整
+                            if (newTop < screenTop - windowThickness) {
+                                newTop = screenTop;
+                            }
+                            // 画面右にはみ出さないように調整
+                            if (newLeft + targetWidth > screenLeft + screenWidth + windowThickness) {
+                                newLeft = screenLeft + screenWidth - targetWidth + windowThickness;
+                            }
+                            // 画面下にはみ出さないように調整
+                            if (newTop + targetHeight > screenTop + screenHeight + windowThickness * 2) {
+                                newTop = screenTop + screenHeight - targetHeight + windowThickness;
+                            }
+
+                            // ウィンドウサイズと位置を変更
+                            chrome.windows.update(
+                                window.id,
+                                {
+                                    width: targetWidth,
+                                    height: targetHeight,
+                                    left: newLeft,
+                                    top: newTop
+                                }
+                            );
+                        });
                     });
                 };
                 container.appendChild(presetBtn);

--- a/popup.js
+++ b/popup.js
@@ -194,9 +194,12 @@ function main() {
     updateWindowInfo();
     chrome.windows.onBoundsChanged.addListener(updateWindowInfo);
     renderPresets();
+
     // バージョン情報の表示
     const manifest = chrome.runtime.getManifest();
-    document.getElementById("version").innerHTML = `${manifest.action.default_title}<br /> Version: ${manifest.version}`;
+    const title = manifest.action.default_title || manifest.name;
+    const version = manifest.version;
+    document.getElementById("version").innerHTML = `${title}<br /> Version: ${version}`;
 }
 
 main();

--- a/popup.js
+++ b/popup.js
@@ -151,9 +151,13 @@ function updateWindowInfo() {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         if (tabs[0]) {
             const url = tabs[0].url || "";
-            testText(url);
+            //testText(url);
 
-            if (url.startsWith("chrome://") || url.startsWith("about:")) {
+            if (url.startsWith("chrome://")
+                || url.startsWith("about:")
+                || url.startsWith("chrome-extension://")
+                || url.startsWith("edge://")
+            ) {
                 // 内部ページはスクリプト注入不可 → 表示領域サイズは取得しない
                 contentText += " | Content: (not accessible)";
             } else {


### PR DESCRIPTION
### 概要
リサイズ処理時に発生していた `Invalid value for bounds` エラーを回避するため、
ウィンドウ位置を先に調整してからリサイズするロジックを導入しました。

### 変更点
- popup.js
  - リサイズ前にウィンドウ位置を補正し、画面表示領域の 50%以上を確保するよう修正
   #10 対応
  - これにより「境界が画面表示領域の 50% 未満」の場合でもエラーが発生せず正常にリサイズ可能
- index.html / index.css
  - Reset ボタンを追加し、UI を改善
  - Back ボタンのアイコンを ↩️ に変更
- manifest.json
  - バージョンを 1.21 に更新

### 効果
- Windows11 Chrome / ChromeOS Flex など複数環境で再現していたエラーを回避
- リセットやプリセット適用時に即座に正常動作するよう改善
- ユーザー体験の安定性が向上し、信頼性を確保
